### PR TITLE
convert deprecated std.array_list.Managed to std.ArrayList

### DIFF
--- a/src/app_runner.zig
+++ b/src/app_runner.zig
@@ -70,7 +70,7 @@ pub const AppRunner = struct {
                 const writer = &stdout.interface;
 
                 _ = writer.write("\n") catch unreachable;
-                try help.print_command_help(app, try cr.command_path.toOwnedSlice(), cr.global_options);
+                try help.print_command_help(app, try cr.command_path.toOwnedSlice(self.orig_allocator), cr.global_options);
             }
             std.posix.exit(1);
         }


### PR DESCRIPTION
This means that you have to explicitly pass an allocator for some operations like append and toOwnedSlice for ArrayLists now. This is part of the ethos of zig.